### PR TITLE
Pass surrogate refresh tokens to the client

### DIFF
--- a/Web Flow With External Server Posting Back/substitutions.sh
+++ b/Web Flow With External Server Posting Back/substitutions.sh
@@ -32,3 +32,8 @@ export OAUTH_SERVER_ROOT=${OAUTH_PUBLIC_SERVER_HOST}:${OAUTH_DEV_SERVER_PORT}
 
 # Callback configured in the Connected App and used in token requests to Salesforce.
 export OAUTH_CALLBACK=${OAUTH_SERVER_ROOT}/callback
+
+# Connection string for REDIS. Enable this in order to perform the experiment with surrogate
+# refresh tokens. REDIS is used to store the mappings between surrogate tokens and the real
+# tokens. 
+#export REDIS_URL=redis://localhost:6379

--- a/Web Flow With External Server Posting Back/webserver/package-lock.json
+++ b/Web Flow With External Server Posting Back/webserver/package-lock.json
@@ -9,7 +9,10 @@
       "version": "1.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "express": "^4.18.2"
+        "@types/redis": "^4.0.11",
+        "body-parser": "^1.20.2",
+        "express": "^4.18.2",
+        "redis": "^4.6.6"
       },
       "devDependencies": {
         "@types/express": "^4.17.15",
@@ -85,6 +88,59 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.5.7",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/@redis/client/-/client-1.5.7.tgz",
+      "integrity": "sha512-gaOBOuJPjK5fGtxSseaKgSvjiZXQCdLlGg9WYQst+/GRUjmXaiB5kVkeQMRtPc7Q2t93XZcJfBMSwzs/XS9UZw==",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/@redis/graph/-/graph-1.1.0.tgz",
+      "integrity": "sha512-16yZWngxyXPd+MJxeSr0dqh2AIOi8j9yXKcKCwVaKDbH3HTuETpDVPcLujhFYVPtYrngSco31BUcSa9TH31Gqg==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/@redis/json/-/json-1.0.4.tgz",
+      "integrity": "sha512-LUZE2Gdrhg0Rx7AN+cZkb1e6HjoSKaeeW8rYnt89Tly13GBI5eP4CwDVr+MY8BAYfCg4/N15OUrtLoona9uSgw==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/@redis/search/-/search-1.1.2.tgz",
+      "integrity": "sha512-/cMfstG/fOh/SsE+4/BQGeuH/JJloeWuH+qJzM8dbxuWvdWibWAOAHHCZTMPhV3xIlH4/cUEIA8OV5QnYpaVoA==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/@redis/time-series/-/time-series-1.0.4.tgz",
+      "integrity": "sha512-ThUIgo2U/g7cCuZavucQTQzA9g9JbDDY2f64u3AbAoz/8vE2lt2U37LamDUVChhaDA3IRT9R6VvJwqnUfTJzng==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
       }
     },
     "node_modules/@types/body-parser": {
@@ -184,6 +240,15 @@
       "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
+    },
+    "node_modules/@types/redis": {
+      "version": "4.0.11",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/@types/redis/-/redis-4.0.11.tgz",
+      "integrity": "sha512-bI+gth8La8Wg/QCR1+V1fhrL9+LZUSWfcqpOj2Kc80ZQ4ffbdL173vQd5wovmoV9i071FU9oP2g6etLuEwb6Rg==",
+      "deprecated": "This is a stub types definition. redis provides its own type definitions, so you do not need this installed.",
+      "dependencies": {
+        "redis": "*"
+      }
     },
     "node_modules/@types/serve-static": {
       "version": "1.15.0",
@@ -469,12 +534,12 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
     "node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "version": "1.20.2",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
       "dependencies": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
@@ -482,7 +547,7 @@
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
         "qs": "6.11.0",
-        "raw-body": "2.5.1",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       },
@@ -598,6 +663,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/color-convert/-/color-convert-2.0.1.tgz",
@@ -640,9 +713,9 @@
       }
     },
     "node_modules/content-type": {
-      "version": "1.0.4",
-      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "version": "1.0.5",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -864,6 +937,43 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/express/node_modules/body-parser": {
+      "version": "1.20.1",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/body-parser/-/body-parser-1.20.1.tgz",
+      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.11.0",
+        "raw-body": "2.5.1",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/express/node_modules/raw-body": {
+      "version": "2.5.1",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/raw-body/-/raw-body-2.5.1.tgz",
+      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -947,6 +1057,14 @@
       "version": "1.1.1",
       "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/get-intrinsic": {
       "version": "1.1.3",
@@ -1433,9 +1551,9 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "version": "2.5.2",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -1456,6 +1574,19 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/redis": {
+      "version": "4.6.6",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/redis/-/redis-4.6.6.tgz",
+      "integrity": "sha512-aLs2fuBFV/VJ28oLBqYykfnhGGkFxvx0HdCEBYdJ99FFbSEMZ7c1nVKwR6ZRv+7bb7JnC0mmCzaqu8frgOYhpA==",
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.5.7",
+        "@redis/graph": "1.1.0",
+        "@redis/json": "1.0.4",
+        "@redis/search": "1.1.2",
+        "@redis/time-series": "1.0.4"
       }
     },
     "node_modules/resolve": {
@@ -2001,8 +2132,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   },
   "dependencies": {
@@ -2060,6 +2190,46 @@
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
+    },
+    "@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "requires": {}
+    },
+    "@redis/client": {
+      "version": "1.5.7",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/@redis/client/-/client-1.5.7.tgz",
+      "integrity": "sha512-gaOBOuJPjK5fGtxSseaKgSvjiZXQCdLlGg9WYQst+/GRUjmXaiB5kVkeQMRtPc7Q2t93XZcJfBMSwzs/XS9UZw==",
+      "requires": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      }
+    },
+    "@redis/graph": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/@redis/graph/-/graph-1.1.0.tgz",
+      "integrity": "sha512-16yZWngxyXPd+MJxeSr0dqh2AIOi8j9yXKcKCwVaKDbH3HTuETpDVPcLujhFYVPtYrngSco31BUcSa9TH31Gqg==",
+      "requires": {}
+    },
+    "@redis/json": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/@redis/json/-/json-1.0.4.tgz",
+      "integrity": "sha512-LUZE2Gdrhg0Rx7AN+cZkb1e6HjoSKaeeW8rYnt89Tly13GBI5eP4CwDVr+MY8BAYfCg4/N15OUrtLoona9uSgw==",
+      "requires": {}
+    },
+    "@redis/search": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/@redis/search/-/search-1.1.2.tgz",
+      "integrity": "sha512-/cMfstG/fOh/SsE+4/BQGeuH/JJloeWuH+qJzM8dbxuWvdWibWAOAHHCZTMPhV3xIlH4/cUEIA8OV5QnYpaVoA==",
+      "requires": {}
+    },
+    "@redis/time-series": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/@redis/time-series/-/time-series-1.0.4.tgz",
+      "integrity": "sha512-ThUIgo2U/g7cCuZavucQTQzA9g9JbDDY2f64u3AbAoz/8vE2lt2U37LamDUVChhaDA3IRT9R6VvJwqnUfTJzng==",
+      "requires": {}
     },
     "@types/body-parser": {
       "version": "1.19.2",
@@ -2158,6 +2328,14 @@
       "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
+    },
+    "@types/redis": {
+      "version": "4.0.11",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/@types/redis/-/redis-4.0.11.tgz",
+      "integrity": "sha512-bI+gth8La8Wg/QCR1+V1fhrL9+LZUSWfcqpOj2Kc80ZQ4ffbdL173vQd5wovmoV9i071FU9oP2g6etLuEwb6Rg==",
+      "requires": {
+        "redis": "*"
+      }
     },
     "@types/serve-static": {
       "version": "1.15.0",
@@ -2404,12 +2582,12 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
     "body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "version": "1.20.2",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
       "requires": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
@@ -2417,7 +2595,7 @@
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
         "qs": "6.11.0",
-        "raw-body": "2.5.1",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       }
@@ -2507,6 +2685,11 @@
         "shallow-clone": "^3.0.0"
       }
     },
+    "cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/color-convert/-/color-convert-2.0.1.tgz",
@@ -2543,9 +2726,9 @@
       }
     },
     "content-type": {
-      "version": "1.0.4",
-      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+      "version": "1.0.5",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
     },
     "cookie": {
       "version": "0.5.0",
@@ -2715,6 +2898,38 @@
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "body-parser": {
+          "version": "1.20.1",
+          "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/body-parser/-/body-parser-1.20.1.tgz",
+          "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+          "requires": {
+            "bytes": "3.1.2",
+            "content-type": "~1.0.4",
+            "debug": "2.6.9",
+            "depd": "2.0.0",
+            "destroy": "1.2.0",
+            "http-errors": "2.0.0",
+            "iconv-lite": "0.4.24",
+            "on-finished": "2.4.1",
+            "qs": "6.11.0",
+            "raw-body": "2.5.1",
+            "type-is": "~1.6.18",
+            "unpipe": "1.0.0"
+          }
+        },
+        "raw-body": {
+          "version": "2.5.1",
+          "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/raw-body/-/raw-body-2.5.1.tgz",
+          "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+          "requires": {
+            "bytes": "3.1.2",
+            "http-errors": "2.0.0",
+            "iconv-lite": "0.4.24",
+            "unpipe": "1.0.0"
+          }
+        }
       }
     },
     "fast-deep-equal": {
@@ -2782,6 +2997,11 @@
       "version": "1.1.1",
       "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g=="
     },
     "get-intrinsic": {
       "version": "1.1.3",
@@ -3154,9 +3374,9 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "version": "2.5.2",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "requires": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -3171,6 +3391,19 @@
       "dev": true,
       "requires": {
         "resolve": "^1.20.0"
+      }
+    },
+    "redis": {
+      "version": "4.6.6",
+      "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/redis/-/redis-4.6.6.tgz",
+      "integrity": "sha512-aLs2fuBFV/VJ28oLBqYykfnhGGkFxvx0HdCEBYdJ99FFbSEMZ7c1nVKwR6ZRv+7bb7JnC0mmCzaqu8frgOYhpA==",
+      "requires": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.5.7",
+        "@redis/graph": "1.1.0",
+        "@redis/json": "1.0.4",
+        "@redis/search": "1.1.2",
+        "@redis/time-series": "1.0.4"
       }
     },
     "resolve": {
@@ -3562,8 +3795,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://artifactory.dev.financialforce.com/artifactory/api/npm/ffdc-npm/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/Web Flow With External Server Posting Back/webserver/package.json
+++ b/Web Flow With External Server Posting Back/webserver/package.json
@@ -10,8 +10,10 @@
   "author": "Richard Corfield",
   "license": "BSD-3-Clause",
   "dependencies": {
+    "@types/redis": "^4.0.11",
+    "body-parser": "^1.20.2",
     "express": "^4.18.2",
-    "body-parser": "^1.20.2"
+    "redis": "^4.6.6"
   },
   "devDependencies": {
     "@types/express": "^4.17.15",

--- a/Web Flow With External Server Posting Back/webserver/src/index.ts
+++ b/Web Flow With External Server Posting Back/webserver/src/index.ts
@@ -10,12 +10,15 @@ import { newRefreshRoute } from './refreshRoute';
 import fs from 'fs';
 import https from 'https';
 import path from 'path';
+import { RedisSurrogateTokenTransform, TokenTransform, UnityTokenTransform } from './tokenTransform';
+import { connectToRedis } from './redisClient';
 
 const KEY = process.env.OAUTH_KEY;
 const SECRET = process.env.OAUTH_SECRET;
 const CALLBACK_URL = process.env.OAUTH_CALLBACK;
 const PORT = process.env.OAUTH_DEV_SERVER_PORT;
 const LETSENCRYPT_DOMAIN_PATH = process.env.LETSENCRYPT_DOMAIN_PATH;
+const REDIS = process.env.REDIS_URL;
 
 if (!KEY || !SECRET || !CALLBACK_URL || !PORT) {
     console.error(
@@ -24,30 +27,37 @@ if (!KEY || !SECRET || !CALLBACK_URL || !PORT) {
     exit(1);
 }
 
-const oAuth: OAuthClient = new OAuthClient({
-    client_id: KEY!,
-    client_secret: SECRET!,
-    redirect_uri: CALLBACK_URL!
-});
+(async function() {
+    const refreshTokenTransform : TokenTransform = REDIS ?
+        new RedisSurrogateTokenTransform(await connectToRedis(REDIS)) :
+        new UnityTokenTransform();
 
-const app = express();
-app.use('/start', newStartRoute(oAuth));
-app.use('/callback', newWebFlowRoute(oAuth));
-app.use('/refresh', newRefreshRoute(oAuth));
-
-const port: number = parseInt(PORT!);
-
-if(LETSENCRYPT_DOMAIN_PATH) {
-    const credentials = {
-        key: fs.readFileSync(path.join(LETSENCRYPT_DOMAIN_PATH, 'privkey.pem'), 'utf-8'),
-        cert: fs.readFileSync(path.join(LETSENCRYPT_DOMAIN_PATH, 'cert.pem'), 'utf-8'),
-        ca: fs.readFileSync(path.join(LETSENCRYPT_DOMAIN_PATH, 'chain.pem'), 'utf-8')
-    };
-    const server = https.createServer(credentials, app);
-    server.listen(port, () => {
-        console.log(`DEMONSTRATION OAuth Web Flow HTTPS server listening on ${port}`);
+    const oAuth: OAuthClient = new OAuthClient({
+        client_id: KEY!,
+        client_secret: SECRET!,
+        redirect_uri: CALLBACK_URL!,
+        refreshTokenTransform
     });
-} else {
-    console.log(`Starting DEMONSTRATION OAuth Web Flow server on ${port}`);
-    app.listen(port);
-}
+
+    const app = express();
+    app.use('/start', newStartRoute(oAuth));
+    app.use('/callback', newWebFlowRoute(oAuth));
+    app.use('/refresh', newRefreshRoute(oAuth));
+
+    const port: number = parseInt(PORT!);
+
+    if(LETSENCRYPT_DOMAIN_PATH) {
+        const credentials = {
+            key: fs.readFileSync(path.join(LETSENCRYPT_DOMAIN_PATH, 'privkey.pem'), 'utf-8'),
+            cert: fs.readFileSync(path.join(LETSENCRYPT_DOMAIN_PATH, 'cert.pem'), 'utf-8'),
+            ca: fs.readFileSync(path.join(LETSENCRYPT_DOMAIN_PATH, 'chain.pem'), 'utf-8')
+        };
+        const server = https.createServer(credentials, app);
+        server.listen(port, () => {
+            console.log(`DEMONSTRATION OAuth Web Flow HTTPS server listening on ${port}`);
+        });
+    } else {
+        console.log(`Starting DEMONSTRATION OAuth Web Flow server on ${port}`);
+        app.listen(port);
+    }
+})();

--- a/Web Flow With External Server Posting Back/webserver/src/redisClient.ts
+++ b/Web Flow With External Server Posting Back/webserver/src/redisClient.ts
@@ -1,0 +1,20 @@
+import {RedisClientType, createClient} from 'redis';
+
+export type RedisClient = ReturnType<typeof createClient>;
+
+/**
+ * Connect to Redis using the given URL
+ * @param clientUrl 
+ * @returns the connected client.
+ */
+export async function connectToRedis(clientUrl : string) : Promise<RedisClient> {
+    const client = createClient({
+        url: clientUrl
+    });
+
+    await(client.connect());
+
+    console.log('Connected to REDIS');
+
+    return client;
+}

--- a/Web Flow With External Server Posting Back/webserver/src/tokenTransform.ts
+++ b/Web Flow With External Server Posting Back/webserver/src/tokenTransform.ts
@@ -1,0 +1,98 @@
+import { RedisClient } from './redisClient';
+import crypto from 'crypto';
+
+// Size of the surrogate token in bytes. It will be base64 encoded, so the final length will be 4/3 this size.
+const SURROGATE_TOKEN_BYTES = 42;
+// Token lifespan in seconds. It can be short in demo code. It will want to be a lot longer in a live system.
+const SURROGATE_TOKEN_LIFESPAN = 5 * 60;
+// Start pruning keys for a given user after this amount of keys.
+const MAX_KEYS_PER_USER = 4;
+
+export type TokenToClientTransformRequest = {
+    /** The token to transform. */
+    token: string;
+    /** This is the ID returned by Salesforce. It looks like https://test.salesforce.com/id/00DDS000000uj0Y2AQ/005DS00000ugbMiYAI */
+    userId: string;
+}
+
+export interface TokenTransform {
+    sfToClient(args: TokenToClientTransformRequest) : Promise<string>;
+    clientToSf(clientForm: string) : Promise<string>;
+}
+
+/**
+ * A transform that does not change its input. The client will receive the unaltered token.
+ */
+export class UnityTokenTransform implements TokenTransform {
+    public sfToClient({token} : TokenToClientTransformRequest): Promise<string> {
+        return Promise.resolve(token);
+    }
+
+    public clientToSf(clientForm: string): Promise<string> {
+        return Promise.resolve(clientForm);
+    }
+}
+
+/**
+ * A transform that generates surrogate tokens. These are mapped to the real tokens using a Redis
+ * database.
+ */
+export class RedisSurrogateTokenTransform implements TokenTransform {
+    public constructor(private redis: RedisClient) {}
+
+    public async sfToClient({token, userId} : TokenToClientTransformRequest): Promise<string> {
+        const uid = crypto.randomBytes(SURROGATE_TOKEN_BYTES).toString('base64'); // Base64 works on blocks of 3 bytes.
+        const storeKey = newTokenKey(uid);
+        await this.storeToken(storeKey, token);
+        await this.maintainUserTokenStoreLimit(userId, uid);
+        return uid;
+    }
+
+    private storeToken(storeKey: string, token: string) : Promise<void> {
+        return this.redis.set(storeKey, token, {
+            EX: SURROGATE_TOKEN_LIFESPAN,
+            NX: true
+        }).then(setResult => {
+            if(setResult !== 'OK') {
+                throw new Error('Unable to store the token in Redis');
+            }    
+        });
+    }
+
+    // This prevents a single user creating a lot of records.
+    // A potential risk here is that we now have a mapping between users and their tokens.
+    // So anyone with access to the database can easily find tokens to try for any target user
+    // or org. Without this an attacker would have to try all keys in the database to find one
+    // for their target user. Not a problem if we assume that the database is secure? If the
+    // database is lost then is having to brute force search all keys much an impediment anyway?
+    private async maintainUserTokenStoreLimit(userId: string, uid: string) : Promise<void> {
+        const listKey = `KeyList.${userId}`;
+        const [length] = await this.redis.multi()
+            .rPush(listKey, uid)
+            .expire(listKey, SURROGATE_TOKEN_LIFESPAN)
+            .exec() as [number, number];
+
+        if(length > MAX_KEYS_PER_USER) {
+            // There should be only one. There are potential race conditions here, so I'll only take 
+            // the one to match the one I've just inserted. Then if another thread is also adding
+            // we'll take one item each.
+            const firstKey = await this.redis.lPop(listKey);
+            if(firstKey){
+                // Fire and forget. If the key has expired then this will do nothing.
+                this.redis.del(newTokenKey(firstKey));
+            }
+        }
+    }
+
+    public async clientToSf(clientForm: string): Promise<string> {
+        const getResult = await this.redis.get(`SurrogateToken.${clientForm}`);
+        if(getResult) {
+            return getResult;
+        }
+        throw new Error('Unable to find token');
+    }
+}
+
+function newTokenKey(uid: string) {
+    return `SurrogateToken.${uid}`;
+}


### PR DESCRIPTION
This keeps the real refresh token in REDIS on the server. It attempts to solve a concern that the refresh endpoint on the server could be hit with random requests and would pass those on to Salesforce's OAuth endpoint. There are other ways to solve this.